### PR TITLE
add selinux instructions to install doc

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -29,6 +29,11 @@ Change the permissions of `uploads/`, `data/` and all their subfolders. Sufficie
 
 	chmod -R 777 uploads/ data/
 
+Note, if your system use SELinux, you will need to authorize Apache/nginx to write to `uploads/` and `data/`.  Without doing this, you will get a permissions error during installation.  To correct the SELinux contexts of these two directories, run this from the Lychee directory.
+
+    semanage fcontext -a -t httpd_sys_rw_content_t "$PWD/data(/.*)?" "$PWD/uploads/(/.*)?"
+    restorecon -vR data uploads
+
 ### 4. Finish
 
 Open Lychee in your browser and follow the given steps.


### PR DESCRIPTION
When installing Lychee, I found that the `data/` dir did not have the `httpd_sys_rw_content_t` SELinux context, which caused the Lychee installer to claim `data/` was not chmodded 777.  In fact, it was 777, which could be rather confusing.  Here's a proposed addition to the install doc that includes SELinux commands to fix this problem.

I should note that the `uploads/` directory did already have the `httpd_sys_rw_content_t` context on my system (Fedora 27), but I included it in case that doesn't hold true for all systems.

Happy to make any requested adjustments.